### PR TITLE
Added Plugin for gzip compression

### DIFF
--- a/Amfphp/Plugins/AmfphpGzip/AmfphpGzip.php
+++ b/Amfphp/Plugins/AmfphpGzip/AmfphpGzip.php
@@ -36,7 +36,7 @@ class AmfphpGzip {
      */
     public function  __construct(array $config = null) {
 
-        if(!$this->is_compression_enable) {
+        if(!$this->is_compression_enable()) {
             return;
         }
 


### PR DESCRIPTION
The plugin checks for compatibilty with `gzcompress`  function (http://php.net/manual/es/function.gzcompress.php)

Allows some configuration:

``` php
$options = array(
   'level' => 6; //Default is 9 (maximum)
);
$this->pluginsConfig["AmfphpGzip"] = $options;
```
