### PR TITLE
added annotation to be able to ignore methods in ServiceBrowser

### DIFF
--- a/BackOffice/ServiceBrowser.php
+++ b/BackOffice/ServiceBrowser.php
@@ -134,7 +134,10 @@ $isAccessGranted = $accessManager->isAccessGranted();
                 echo "\n <li><b>$service->name</b>";
                 echo "\n<ul>";
                 foreach ($service->methods as $method) {
-                    if (substr($method->name, 0, 1) == '_') {
+                    if (
+                        substr($method->name, 0, 1) == '_'
+                        || false !== strpos($method->comment, '@amfIgnore')
+                    ) {
                         //methods starting with a '_' as they are reserved, so filter them out 
                         continue;
                     }


### PR DESCRIPTION
I don't want to prefix my methods with a '_', so I added another check that looks for a specific annotation.
