### PR TITLE
Fix deprecation on PHP 7

### DIFF
--- a/Amfphp/Core/Amf/Deserializer.php
+++ b/Amfphp/Core/Amf/Deserializer.php
@@ -744,7 +744,7 @@ class Amfphp_Core_Amf_Deserializer implements Amfphp_Core_Common_IDeserializer {
         $data = '';
         for ($i = 0; $i < $len; $i++) {
             $data .= $this->rawData
-                    {$i + $this->currentByte};
+                    [$i + $this->currentByte];
         }
         $this->currentByte += $len;
         return $data;

--- a/Amfphp/Core/Amf/Handler.php
+++ b/Amfphp/Core/Amf/Handler.php
@@ -119,7 +119,7 @@ class Amfphp_Core_Amf_Handler implements Amfphp_Core_Common_IDeserializer, Amfph
         $split = explode('/', $targetUri);
         $ret = new Amfphp_Core_Common_ServiceCallParameters();
         $ret->methodName = array_pop($split);
-        $ret->serviceName = join($split, '/');
+        $ret->serviceName = join('/', $split);
         $ret->methodParameters = $Amfphp_Core_Amf_Message->data;
         return $ret;
     }


### PR DESCRIPTION
This PR fixes:
- Deprecated access an array with curly braces
- Deprecated parameter for join(). Parameter swapped from join($array, $separator) to join($separator, $array)

